### PR TITLE
Tree API: Automatic creation of growing functions (with schematic)

### DIFF
--- a/mods/default/lua/apis/tree_growing.lua
+++ b/mods/default/lua/apis/tree_growing.lua
@@ -116,6 +116,8 @@ function default.grow_apple_tree(pos, is_apple_tree, bad)
 	vm:set_data(data)
 	vm:write_to_map()
 	vm:update_map()
+	
+	return true
 end
 
 
@@ -168,6 +170,8 @@ function default.grow_jungle_tree(pos, bad)
 	vm:set_data(data)
 	vm:write_to_map()
 	vm:update_map()
+	
+	return true
 end
 
 
@@ -310,4 +314,6 @@ function default.grow_pine_tree(pos)
 	vm:set_data(data)
 	vm:write_to_map()
 	vm:update_map()
+	
+	return true
 end

--- a/mods/default/lua/apis/tree_growing.lua
+++ b/mods/default/lua/apis/tree_growing.lua
@@ -1,4 +1,4 @@
--- mods/default/lua/trees.lua
+-- mods/default/lua/apis/tree_growing.lua
 
 local random = math.random
 
@@ -21,53 +21,9 @@ function default.can_grow(pos)
 	return true
 end
 
-function default.grow_sapling(pos)
-	local node = core.get_node(pos)
-	
-	if not default.can_grow(pos) then
-		return false
-	end
-
-	local mapgen = core.get_mapgen_params().mgname
-	if node.name == "default:sapling" then
-		core.log("action", "A sapling grows into a tree at "..
-			core.pos_to_string(pos))
-		if mapgen == "v6" then
-			default.grow_tree(pos, random(1, 4) == 1)
-		else
-			default.grow_new_apple_tree(pos)
-		end
-		return true
-	elseif node.name == "default:junglesapling" then
-		core.log("action", "A jungle sapling grows into a tree at "..
-			core.pos_to_string(pos))
-		if mapgen == "v6" then
-			default.grow_jungle_tree(pos)
-		else
-			default.grow_new_jungle_tree(pos)
-		end
-		return true
-	elseif node.name == "default:pine_sapling" then
-		core.log("action", "A pine sapling grows into a tree at "..
-			core.pos_to_string(pos))
-		if mapgen == "v6" then
-			default.grow_pine_tree(pos)
-		else
-			default.grow_new_pine_tree(pos)
-		end
-		return true
-	elseif node.name == "default:acacia_sapling" then
-		core.log("action", "An acacia sapling grows into a tree at "..
-			core.pos_to_string(pos))
-		default.grow_new_acacia_tree(pos)
-	elseif node.name == "default:birch_sapling" then
-		core.log("action", "An birch sapling grows into a tree at "..
-			core.pos_to_string(pos))
-		default.grow_new_birch_tree(pos)
-		return true
-	end
-end
-
+-- for global tree growing functions (will be filled with default.register_tree)
+default.grow_mgv6_tree = {}
+default.grow_tree = {}
 
 --
 -- Tree generation
@@ -135,15 +91,12 @@ end
 
 -- Apple tree
 
-function default.grow_tree(pos, is_apple_tree, bad)
+function default.grow_apple_tree(pos, is_apple_tree, bad)
 	--[[
 		NOTE: Tree-placing code is currently duplicated in the engine
 		and in games that have saplings; both are deprecated but not
 		replaced yet
 	--]]
-	if bad then
-		error("Deprecated use of default.grow_tree")
-	end
 
 	local x, y, z = pos.x, pos.y, pos.z
 	local height = random(4, 5)
@@ -358,47 +311,3 @@ function default.grow_pine_tree(pos)
 	vm:write_to_map()
 	vm:update_map()
 end
-
-
--- New apple tree
-
-function default.grow_new_apple_tree(pos)
-	local path = core.get_modpath("default") .. "/schematics/apple_tree_from_sapling.mts"
-	core.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
-		path, 0, nil, false)
-end
-
-
--- New jungle tree
-
-function default.grow_new_jungle_tree(pos)
-	local path = core.get_modpath("default") .. "/schematics/jungle_tree_from_sapling.mts"
-	core.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
-		path, 0, nil, false)
-end
-
-
--- New pine tree
-
-function default.grow_new_pine_tree(pos)
-	local path = core.get_modpath("default") .. "/schematics/pine_tree_from_sapling.mts"
-	core.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
-		path, 0, nil, false)
-end
-
-
--- New acacia tree
-
-function default.grow_new_acacia_tree(pos)
-	local path = core.get_modpath("default") .. "/schematics/acacia_tree_from_sapling.mts"
-	core.place_schematic({x = pos.x - 4, y = pos.y - 1, z = pos.z - 4},
-		path, random, nil, false)
-end
-
- -- New birch tree
-
- function default.grow_new_birch_tree(pos)
-	 local path = core.get_modpath("default") .. "/schematics/birch_tree_from_sapling.mts"
-	 core.place_schematic({x = pos.x - 2, y = pos.y - 1, z = pos.z - 2},
-	 	path, 0, nil, false)
- end

--- a/mods/default/lua/apis/trees.lua
+++ b/mods/default/lua/apis/trees.lua
@@ -63,7 +63,7 @@ end
 function default.register_sapling(name, def)
 	local growtime = def.growtime or 300
 	growtime = growtime * default.GROW_TIME_FACTOR
-	local on_grow = def.on_grow or default.grow_sapling
+	local on_grow = def.on_grow
 	
 	def.drawtype = "plantlike"
 	def.tiles = def.tiles or {def.texture}
@@ -133,6 +133,47 @@ function default.register_tree(name, def)
 	-- other values
 	def.leaves.sapling_name = def.sapling.name	or name .. "_sapling"
 
+	-- sapling growing functions
+	if def.sapling.growing_type == "schematic" then
+		default.grow_tree[name] = function(pos)
+			if not default.can_grow(pos) then
+				return false
+			end
+			
+			core.log("action", "A \"" .. def.sapling.description .. "\" grows into a tree at " .. core.pos_to_string(pos))
+			
+			local path = def.schematic
+			core.place_schematic({x = pos.x - def.schematic_size.x, y = pos.y - def.schematic_size.y, z = pos.z - def.schematic_size.z}, path, math.random, def.schematic_replace or nil, false)
+			return true
+		end
+		-- set the sapling growing function
+		def.sapling.on_grow = default.grow_tree[name]
+	elseif def.sapling.growing_type == "schematic_and_function" then
+		default.grow_mgv6_tree[name] = def.sapling.mgv6_grow
+		
+		default.grow_tree = nil
+		default.grow_tree = {}
+		
+		default.grow_tree[name] = function(pos)
+			if not default.can_grow(pos) then
+				return false
+			end
+			
+			core.log("action", "A \"" .. def.sapling.description .. "\" grows into a tree at " .. core.pos_to_string(pos))
+			
+			if core.get_mapgen_params().mgname == "v6" then
+				-- grow tree with function
+				default.grow_mgv6_tree[name](pos)
+			else
+				-- place schematic
+				local path = def.schematic
+				core.place_schematic({x = pos.x - def.schematic_size.x, y = pos.y - def.schematic_size.y, z = pos.z - def.schematic_size.z}, path, math.random, def.schematic_replace or nil, false)
+			end
+			return true
+		end
+		-- set the sapling growing function
+		def.sapling.on_grow = default.grow_tree[name]
+	end
 
 	-- log / tree
 	if def.register.log then

--- a/mods/default/lua/apis/trees.lua
+++ b/mods/default/lua/apis/trees.lua
@@ -151,9 +151,6 @@ function default.register_tree(name, def)
 	elseif def.sapling.growing_type == "schematic_and_function" then
 		default.grow_mgv6_tree[name] = def.sapling.mgv6_grow
 		
-		default.grow_tree = nil
-		default.grow_tree = {}
-		
 		default.grow_tree[name] = function(pos)
 			if not default.can_grow(pos) then
 				return false

--- a/mods/default/lua/nodes/trees.lua
+++ b/mods/default/lua/nodes/trees.lua
@@ -1,4 +1,7 @@
-default.register_tree(nil, {
+default.register_tree("default:apple_tree", { -- can be used for default.grow_tree[<tree name>](pos)
+	schematic = core.get_modpath("default") .. "/schematics/apple_tree_from_sapling.mts",
+	schematic_size = {x = 2, y = 1, z = 2},
+	-- not the real size of the schematic, its about how much the schematic has to move from the pos of the sapling
 	log = {
 		name = "default:tree",
 		description = "Log",
@@ -14,6 +17,11 @@ default.register_tree(nil, {
 		name = "default:sapling",
 		description = "Sapling",
 		texture = "default_sapling.png",
+		growtime = 300,
+		growing_type = "schematic_and_function",
+		mgv6_grow = function(pos)
+			default.grow_apple_tree(pos, math.random(1, 4) == 1) --  see mods/default/lua/apis/tree_growing
+		end
 	},
 	planks = {
 		name = "default:wood",
@@ -23,8 +31,10 @@ default.register_tree(nil, {
 	},
 })
 
-default.register_tree(nil, {
+default.register_tree("default:jungle", {
 	description = "Jungle",
+	schematic = core.get_modpath("default") .. "/schematics/jungle_tree_from_sapling.mts",
+	schematic_size = {x = 2, y = 1, z = 2},
 	log = {
 		name = "default:jungletree",
 		tiles = {"default_jungletree_top.png", "default_jungletree_top.png", "default_jungletree.png"}
@@ -39,7 +49,11 @@ default.register_tree(nil, {
 		name = "default:junglesapling",
 		description = "Jungle Sapling",
 		texture = "default_junglesapling.png",
-		growtime = 270 -- 4.5 min -> in average 5.4 min
+		growtime = 270, -- 4.5 min -> in average 5.4 min
+		growing_type = "schematic_and_function",
+		mgv6_grow = function(pos)
+			default.grow_jungle_tree(pos)
+		end
 	},
 	planks = {
 		name = "default:junglewood",
@@ -52,27 +66,39 @@ default.register_tree(nil, {
 default.register_tree("default:pine", {
 	description = "Pine",
 	texture_prefix = "default_pine",
+	schematic = core.get_modpath("default") .. "/schematics/pine_tree_from_sapling.mts",
+	schematic_size = {x = 2, y = 1, z = 2},
 	leaves = {
 		name = "default:pine_needles",
 		description = "Pine Needles",
 		texture = "default_pine_needles.png",
 		texture_special = "default_pine_needles_simple.png",
-		sapling_rarity = 24
+		sapling_rarity = 24,
+	},
+	sapling = {
+		growing_type = "schematic",
+		growtime = 330, -- 5.5 min
 	},
 })
 
 default.register_tree("default:acacia", {
 	description = "Acacia",
 	texture_prefix = "default_acacia",
+	schematic = core.get_modpath("default") .. "/schematics/acacia_tree_from_sapling.mts",
+	schematic_size = {x = 4, y = 1, z = 4},
 	sapling = {
-		growtime = 420 -- 7 min -> in average 8.4 min
+		growtime = 420, -- 7 min -> in average 8.4 min
+		growing_type = "schematic"
 	},
 })
 
 default.register_tree("default:birch", {
 	description = "Birch",
 	texture_prefix = "default_birch",
+	schematic = core.get_modpath("default") .. "/schematics/birch_tree_from_sapling.mts",
+	schematic_size = {x = 2, y = 1, z = 2},
 	sapling = {
-		growtime = 420 -- 7 min -> in average 8.4 min
+		growtime = 420, -- 7 min -> in average 8.4 min
+		growing_type = "schematic"
 	},
 })

--- a/mods/default/lua/nodes/trees.lua
+++ b/mods/default/lua/nodes/trees.lua
@@ -20,7 +20,11 @@ default.register_tree("default:apple_tree", { -- can be used for default.grow_tr
 		growtime = 300,
 		growing_type = "schematic_and_function",
 		mgv6_grow = function(pos)
-			default.grow_apple_tree(pos, math.random(1, 4) == 1) --  see mods/default/lua/apis/tree_growing
+			if not default.can_grow() then
+				return false
+			end
+			
+			return default.grow_apple_tree(pos, math.random(1, 4) == 1) --  see mods/default/lua/apis/tree_growing
 		end
 	},
 	planks = {
@@ -52,6 +56,10 @@ default.register_tree("default:jungle", {
 		growtime = 270, -- 4.5 min -> in average 5.4 min
 		growing_type = "schematic_and_function",
 		mgv6_grow = function(pos)
+			if not default.can_grow() then
+				return false
+			end
+			
 			default.grow_jungle_tree(pos)
 		end
 	},


### PR DESCRIPTION
Now you can give default.register_tree a schematic and it creates a function for it.

Here are some examples:

``` Lua
default.register_tree("default:apple_tree", {
    schematic = core.get_modpath("default") .. "/schematics/apple_tree_from_sapling.mts",
    schematic_size = {x = 2, y = 1, z = 2},
    sapling = {
        growing_type = "schematic_and_function",
        mgv6_grow = function(pos)
            if not default.can_grow() then
                return false
            end

            return default.grow_apple_tree(pos, math.random(1, 4) == 1)
        end,
    }
})

default.register_tree("default:acacia", {
    schematic = core.get_modpath("default") .. "/schematics/acacia_tree_from_sapling.mts",
    schematic_size = {x = 2, y = 1, z = 2},
    sapling = {
        growing_type = "schematic",
    }
})
```
