### PR TITLE
Add 3d ladder

### DIFF
--- a/mods/default/lua/nodes/ladder.lua
+++ b/mods/default/lua/nodes/ladder.lua
@@ -4,22 +4,34 @@
 
 default.register_node("default:ladder", {
 	description = "Ladder",
-	drawtype = "signlike",
-	tiles = {"default_ladder.png"},
+	drawtype = "nodebox",
+	node_box = {
+		type = "fixed",
+		fixed = {
+			{-0.4375, -0.5, 0.375, -0.3125, 0.5, 0.5},
+			{0.3125, -0.5, 0.375, 0.4375, 0.5, 0.5},
+			{-0.5, -0.4375, 0.4375, 0.5, -0.375, 0.5},
+			{-0.5, -0.25, 0.4375, 0.5, -0.1875, 0.5},
+			{-0.5, -0.0625, 0.4375, 0.5, 0, 0.5},
+			{-0.5, 0.125, 0.4375, 0.5, 0.1875, 0.5},
+			{-0.5, 0.3125, 0.4375, 0.5, 0.375, 0.5},
+		}
+	},
+	selection_box = {
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, 0.375, 0.5, 0.5, 0.5},
+		}
+	},
+	tiles = {"default_wood.png"},
 	inventory_image = "default_ladder.png",
 	wield_image = "default_ladder.png",
 	paramtype = "light",
-	paramtype2 = "wallmounted",
+	paramtype2 = "facedir",
 	sunlight_propagates = true,
-	walkable = false,
+	walkable = true,
 	climbable = true,
 	is_ground_content = false,
-	selection_box = {
-		type = "wallmounted",
-		--wall_top = = <default>
-		--wall_bottom = = <default>
-		--wall_side = = <default>
-	},
 	groups = {choppy = 2, oddly_breakable_by_hand = 3, flammable = 2, fuel = 5},
 	legacy_wallmounted = true,
 	sounds = default.node_sound_wood_defaults(),


### PR DESCRIPTION
Add a 3d ladder using a nodebox. I switched walkable to true, because it seemed unlogical to walk through a ladder which is now massive wood.
![screenshot_20161019_154204](https://cloud.githubusercontent.com/assets/16508248/19521070/afddf7c6-9612-11e6-9be9-61e7df0c0da6.png)
